### PR TITLE
Make sure buildpack can be used without jar (perhaps java buildpack)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
+Heroku Buildpack for AWS X-Ray
+===
+
+Installation
+---
+
 Add it to your app:
 
 ```
 heroku buildpacks:add https://github.com/urbandictionary/heroku-buildpack-xray
 ```
+
+Configuration
+---
+
+The AWS X-Ray daemon (https://github.com/aws/aws-xray-daemon/tree/master/daemon) will pick up environment variables like `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and `AWS_REGION` to configure itself.

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ log "Creating .profile.d script..."
 cat > $BUILD_DIR/.profile.d/001-xray-daemon.sh << EOF
 #!/bin/sh
 
-$HOME/bin/xray --local-mode &
+$HOME/bin/xray --log-level prod --local-mode &
 EOF
 
 chmod +x $BUILD_DIR/.profile.d/001-xray-daemon.sh

--- a/bin/compile
+++ b/bin/compile
@@ -17,11 +17,11 @@ mkdir -p $BUILD_DIR/bin
 mkdir -p $BUILD_DIR/.profile.d
 
 log "Downloading X-Ray daemon..."
-wget -nc $XRAY_DOWNLOAD_LINK -P $CACHE_DIR
+wget -nc $XRAY_DOWNLOAD_LINK -O ${CACHE_DIR}/xray.zip
 
 log "Extracting X-Ray daemon executable..."
 cd $CACHE_DIR
-jar xf *.zip
+unzip xray.zip
 chmod +x xray
 cp $CACHE_DIR/xray $BUILD_DIR/bin/xray
 

--- a/bin/compile
+++ b/bin/compile
@@ -21,7 +21,7 @@ wget -nc $XRAY_DOWNLOAD_LINK -O ${CACHE_DIR}/xray.zip
 
 log "Extracting X-Ray daemon executable..."
 cd $CACHE_DIR
-unzip xray.zip
+unzip -o xray.zip
 chmod +x xray
 cp $CACHE_DIR/xray $BUILD_DIR/bin/xray
 

--- a/bin/compile
+++ b/bin/compile
@@ -29,7 +29,7 @@ log "Creating .profile.d script..."
 cat > $BUILD_DIR/.profile.d/001-xray-daemon.sh << EOF
 #!/bin/sh
 
-$HOME/bin/xray --log-level prod --local-mode &
+$HOME/bin/xray --log-level error --local-mode &
 EOF
 
 chmod +x $BUILD_DIR/.profile.d/001-xray-daemon.sh


### PR DESCRIPTION
Basically just by switching `jar` out for `unzip`.

Adds configuration section to README.